### PR TITLE
Add full path to pre-run setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Check the application logs at `https://dashboard.heroku.com/apps/your_app_name/l
 ## Setting up the Sauce Labs test
 Set the `prerun` desired capability, ensuring it runs in the background:
 
-`caps['prerun'] = {executable: 'https://your_app_name.heroku.com/memory_script', background: true}`
+`caps['prerun'] = {executable: 'https://your_app_name.heroku.com/memory_script.py', background: true}`
 (Example for Ruby)
 
 ## Run It


### PR DESCRIPTION
`/memory_script` didn't do it for me.  It seems like it should be `/memory_script.py` and that seems to be the route on the route.rb file.  Unsure if I just missed something.